### PR TITLE
#10: FAMStandard gives correct list of "import"'s for iterable records

### DIFF
--- a/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/FAMStandard.java
+++ b/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/FAMStandard.java
@@ -26,6 +26,7 @@
 package com.pragmaticobjects.oo.meta.model;
 
 import com.pragmaticobjects.oo.meta.freemarker.FreemarkerArtifactModel;
+import com.sun.tools.javac.util.List;
 import io.vavr.collection.Map;
 import java.util.Collection;
 import java.util.Comparator;
@@ -61,6 +62,7 @@ public class FAMStandard implements FreemarkerArtifactModel {
 
     private final Collection<Type> getImports() {
         return map.values()
+                .flatMap(a -> a instanceof Iterable<?> ? List.from((Iterable<?>) a) : List.of(a))
                 .filter(a -> a instanceof ImportsProvider)
                 .map(a -> (ImportsProvider) a)
                 .flatMap(ip -> ip.getImports())

--- a/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/FAMStandard.java
+++ b/meta-model/src/main/java/com/pragmaticobjects/oo/meta/model/FAMStandard.java
@@ -26,7 +26,7 @@
 package com.pragmaticobjects.oo.meta.model;
 
 import com.pragmaticobjects.oo.meta.freemarker.FreemarkerArtifactModel;
-import com.sun.tools.javac.util.List;
+import io.vavr.collection.List;
 import io.vavr.collection.Map;
 import java.util.Collection;
 import java.util.Comparator;
@@ -62,7 +62,7 @@ public class FAMStandard implements FreemarkerArtifactModel {
 
     private final Collection<Type> getImports() {
         return map.values()
-                .flatMap(a -> a instanceof Iterable<?> ? List.from((Iterable<?>) a) : List.of(a))
+                .flatMap(a -> a instanceof Iterable<?> ? List.ofAll((Iterable<?>) a) : List.of(a))
                 .filter(a -> a instanceof ImportsProvider)
                 .map(a -> (ImportsProvider) a)
                 .flatMap(ip -> ip.getImports())

--- a/meta-model/src/test/java/com/pragmaticobjects/oo/meta/model/FAMStandardTest.java
+++ b/meta-model/src/test/java/com/pragmaticobjects/oo/meta/model/FAMStandardTest.java
@@ -29,6 +29,7 @@ import com.pragmaticobjects.oo.meta.freemarker.AssertFreemarkerModelValue;
 import com.pragmaticobjects.oo.tests.TestCase;
 import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 import io.vavr.collection.HashMap;
+import io.vavr.collection.LinkedHashMap;
 import io.vavr.collection.List;
 import java.util.Collection;
 
@@ -55,13 +56,17 @@ public class FAMStandardTest extends TestsSuite {
                 new AssertFreemarkerModelValue(
                     new FAMStandard(
                         new TypeReferential("com.test", "TestObject"),
-                        HashMap.<String, Object>of(
-                            "somedependency", new TypeReferential("com.dependency", "Dependency")
+                        LinkedHashMap.<String, Object>of(
+                            "somedependency", new TypeReferential("com.dependency", "Dependency"),
+                            "listofdependencies", List.<Type>of(
+                                new TypeReferential("com.dependency", "Dependency2")
+                            )
                         )
                     ),
                     "imports",
                     List.<Type>of(
-                        new TypeReferential("com.dependency", "Dependency")
+                        new TypeReferential("com.dependency", "Dependency"),
+                        new TypeReferential("com.dependency", "Dependency2")
                     ).asJava()
                 )
             )


### PR DESCRIPTION
Closes #10 